### PR TITLE
Refactor method generation for greater clarity and consistency and enrich error messages

### DIFF
--- a/src/dbus_python_client_gen/_invokers.py
+++ b/src/dbus_python_client_gen/_invokers.py
@@ -343,6 +343,9 @@ def invoker_builder(spec, timeout):
     :raises DPClientGenerationError:
     """
 
+    method_builder_arg = method_builder(spec, timeout)
+    prop_builder_arg = prop_builder(spec, timeout)
+
     def builder(namespace):
         """
         Fills the namespace of the parent class with two class members,
@@ -358,14 +361,14 @@ def invoker_builder(spec, timeout):
            types.new_class(
                "Methods",
                bases=(object,),
-               exec_body=method_builder(spec, timeout)
+               exec_body=method_builder_arg
            )
 
         namespace["Properties"] = \
            types.new_class(
                "Properties",
                bases=(object,),
-               exec_body=prop_builder(spec, timeout)
+               exec_body=prop_builder_arg
            )
 
     return builder

--- a/src/dbus_python_client_gen/_invokers.py
+++ b/src/dbus_python_client_gen/_invokers.py
@@ -308,15 +308,17 @@ def method_builder(interface_name, methods, timeout):
     return builder
 
 
-def invoker_builder(spec, timeout):
+def make_class(name, spec, timeout=-1):
     """
-    Returns a function that builds a method interface based on 'spec'.
+    Make a class, name, from the given spec.
+    The class defines static properties and methods according to the spec.
 
+    :param str name: the name of the class.
     :param spec: the interface specification
     :type spec: xml.element.ElementTree.Element
-    :param int timeout: Timeout for dbus client, -1 == libdbus default ~25s.
-
-    :raises DPClientGenerationError:
+    :param int timeout: dbus timeout for method(s), -1 is libdbus default ~25s.
+    :returns: the constructed class
+    :rtype: type
     """
 
     try:
@@ -355,20 +357,4 @@ def invoker_builder(spec, timeout):
                exec_body=prop_builder_arg
            )
 
-    return builder
-
-
-def make_class(name, spec, timeout=-1):
-    """
-    Make a class, name, from the given spec.
-    The class defines static properties and methods according to the spec.
-
-    :param str name: the name of the class.
-    :param spec: the interface specification
-    :type spec: xml.element.ElementTree.Element
-    :param int timeout: dbus timeout for method(s), -1 is libdbus default ~25s.
-    :returns: the constructed class
-    :rtype: type
-    """
-    return types.new_class(
-        name, bases=(object, ), exec_body=invoker_builder(spec, timeout))
+    return types.new_class(name, bases=(object, ), exec_body=builder)

--- a/src/dbus_python_client_gen/_invokers.py
+++ b/src/dbus_python_client_gen/_invokers.py
@@ -77,10 +77,12 @@ def prop_builder(interface_name, properties, timeout):
         try:
             func = xformers(signature)[0]
         except IntoDPError as err:  #pragma: no cover
-            raise DPClientGenerationError(
-                "Failed to generate argument-transforming \
-                        function from signature \"%s\" for property \"%s\""
-                & (signature, name)) from err
+            fmt_str = (
+                "Failed to generate argument-transforming function from "
+                "signature \"%s\" for Set method for property \"%s\" "
+                "belonging to interface \"%s\"")
+            raise DPClientGenerationError(fmt_str % (signature, name,
+                                                     interface_name)) from err
 
         def dbus_func(proxy_object, value):  # pragma: no cover
             """
@@ -166,19 +168,25 @@ def prop_builder(interface_name, properties, timeout):
             try:
                 name = prop.attrib['name']
             except KeyError as err:  # pragma: no cover
-                raise DPClientGenerationError("No name attribute found for property.") \
-                   from err
+                fmt_str = ("No name attribute found for property belonging to "
+                           "interface \"%s\"")
+                raise DPClientGenerationError(
+                    fmt_str % interface_name) from err
 
             try:
                 access = prop.attrib['access']
             except KeyError as err:  # pragma: no cover
-                raise DPClientGenerationError("No access attribute found for property.") \
-                   from err
+                fmt_str = ("No access attribute found for property \"%s\" "
+                           "belonging to interface \"%s\"")
+                raise DPClientGenerationError(fmt_str %
+                                              (name, interface_name)) from err
             try:
                 signature = prop.attrib['type']
             except KeyError as err:  # pragma: no cover
-                raise DPClientGenerationError("No type attribute found for property.") \
-                   from err
+                fmt_str = ("No type attribute found for property \"%s\" "
+                           "belonging to interface \"%s\"")
+                raise DPClientGenerationError(fmt_str %
+                                              (name, interface_name)) from err
 
             namespace[name] = \
                types.new_class(
@@ -224,26 +232,29 @@ def method_builder(interface_name, methods, timeout):
         try:
             arg_names = [e.attrib["name"] for e in inargs]
         except KeyError as err:  # pragma: no cover
-            raise DPClientGenerationError(
-                "Missing name attribute for some argument for method \"%s\"" %
-                name) from err
+            fmt_str = ("No name attribute found for some argument for method "
+                       "\"%s\" belonging to interface \"%s\"")
+            raise DPClientGenerationError(fmt_str % (name,
+                                                     interface_name)) from err
 
         arg_names_set = frozenset(arg_names)
 
         try:
             signature = "".join(e.attrib["type"] for e in inargs)
         except KeyError as err:  #pragma: no cover
-            raise DPClientGenerationError(
-                "Missing type attribute for some argument for method \"%s\"" %
-                name) from err
+            fmt_str = ("No type attribute found for some argument for method "
+                       "\"%s\" belonging to interface \"%s\"")
+            raise DPClientGenerationError(fmt_str % (name,
+                                                     interface_name)) from err
 
         try:
             func = xformer(signature)
         except IntoDPError as err:  #pragma: no cover
-            raise DPClientGenerationError(
-                "Failed to generate argument-transforming \
-                        function from signature \"%s\" for method \"%s\"" %
-                (signature, name)) from err
+            fmt_str = ("Failed to generate argument-transforming function "
+                       "from signature \"%s\" for method \"%s\" belonging to "
+                       "interface \"%s\"")
+            raise DPClientGenerationError(fmt_str % (signature, name,
+                                                     interface_name)) from err
 
         def dbus_func(proxy_object, func_args):  # pragma: no cover
             """
@@ -304,8 +315,10 @@ def method_builder(interface_name, methods, timeout):
             try:
                 name = method.attrib['name']
             except KeyError as err:  # pragma: no cover
-                raise DPClientGenerationError("No name attribute found for method.") \
-                   from err
+                fmt_str = ("No name attribute found for method belonging to "
+                           "interface \"%s\"")
+                raise DPClientGenerationError(
+                    fmt_str % interface_name) from err
 
             the_method = \
                build_method(name, method.findall('./arg[@direction="in"]'))
@@ -331,7 +344,7 @@ def make_class(name, spec, timeout=-1):
         interface_name = spec.attrib['name']
     except KeyError as err:  # pragma: no cover
         raise DPClientGenerationError(
-            "No name attribute found for interface.") from err
+            "No name attribute found for interface") from err
 
     method_builder_arg = \
        method_builder(interface_name, spec.findall("./method"), timeout)

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -57,7 +57,7 @@ class TestCase(unittest.TestCase):
         the properties it should have.
         """
         for name, spec in self._data.items():
-            builder = prop_builder(spec, -1)
+            builder = prop_builder(name, spec.findall("./property"), -1)
             klass = types.new_class(name, bases=(object, ), exec_body=builder)
             for prop in spec.findall("./property"):
                 self._test_property(klass, prop)
@@ -79,7 +79,7 @@ class TestCase(unittest.TestCase):
         the properties it should have.
         """
         for name, spec in self._data.items():
-            builder = method_builder(spec, -1)
+            builder = method_builder(name, spec.findall("./method"), -1)
             klass = types.new_class(name, bases=(object, ), exec_body=builder)
             for method in spec.findall("./method"):
                 self._test_method(klass, method)


### PR DESCRIPTION
Do a bunch of refactoring to simplify generation of invoker methods.

Enrich the DPClientGenerationError messages further.

Get rid of three pylint errors in the process.

Resolves: #7