### PR TITLE
No longer disable invalid-name

### DIFF
--- a/check.py
+++ b/check.py
@@ -6,11 +6,11 @@ import sys
 
 arg_map = {
     "src/dbus_python_client_gen": [
-        "--reports=no", "--disable=I", "--disable=invalid-name",
+        "--reports=no", "--disable=I",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
     ],
     "tests": [
-        "--reports=no", "--disable=I", "--disable=invalid-name",
+        "--reports=no", "--disable=I",
         "--msg-template='{path}:{line}: [{msg_id}({symbol}), {obj}] {msg}'"
     ]
 }

--- a/tests/test_generated.py
+++ b/tests/test_generated.py
@@ -51,7 +51,7 @@ class TestCase(unittest.TestCase):
         if "write" in access:
             self.assertTrue(hasattr(prop_klass, "Set"))
 
-    def _testProperties(self):
+    def _test_properties(self):
         """
         Generate a klass from an interface spec and verify that it has
         the properties it should have.
@@ -73,7 +73,7 @@ class TestCase(unittest.TestCase):
         name = method.attrib['name']
         self.assertTrue(hasattr(klass, name))
 
-    def _testMethods(self):
+    def _test_methods(self):
         """
         Generate a class from an interface spec and verify that it has
         the properties it should have.
@@ -84,7 +84,7 @@ class TestCase(unittest.TestCase):
             for method in spec.findall("./method"):
                 self._test_method(klass, method)
 
-    def _testKlass(self):
+    def _test_klass(self):
         """
         Generate a class from an interface spec and verify that it has two
         fields, "Properties" and "Methods".
@@ -101,10 +101,10 @@ class TestCase(unittest.TestCase):
             for prop in spec.findall("./property"):
                 self._test_property(properties, prop)
 
-    def testSpecs(self):
+    def test_specs(self):
         """
         Test properties and methods of all specs available.
         """
-        self._testProperties()
-        self._testMethods()
-        self._testKlass()
+        self._test_properties()
+        self._test_methods()
+        self._test_klass()


### PR DESCRIPTION
Even pylint thinks all names in src are good, and test names are easy to
change.

Signed-off-by: mulhern <amulhern@redhat.com>