### PR TITLE
Pin dbus-python to 1.2.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=lint,test,coverage
 [testenv:coverage]
 deps =
     coverage
+    dbus-python==1.2.4
     hypothesis
     pytest>=2.8
 commands =
@@ -14,6 +15,7 @@ commands =
 
 [testenv:lint]
 deps =
+    dbus-python==1.2.4
     hypothesis
     pylint
     pytest>=2.8
@@ -23,6 +25,7 @@ commands =
 
 [testenv:test]
 deps =
+    dbus-python==1.2.4
     hypothesis
     pytest>=2.8
 commands =


### PR DESCRIPTION
All available subsequent versions require libdbus 1.8 which Travis does not
supply.

Signed-off-by: mulhern <amulhern@redhat.com>