### PR TITLE
Remove hypothesis dependency in tox file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist=lint,test,coverage
 deps =
     coverage
     dbus-python==1.2.4
-    hypothesis
     pytest>=2.8
 commands =
     coverage --version
@@ -16,7 +15,6 @@ commands =
 [testenv:lint]
 deps =
     dbus-python==1.2.4
-    hypothesis
     pylint
     pytest>=2.8
 commands =
@@ -26,7 +24,6 @@ commands =
 [testenv:test]
 deps =
     dbus-python==1.2.4
-    hypothesis
     pytest>=2.8
 commands =
     py.test tests


### PR DESCRIPTION
Hypothesis dependency must have gone away a while ago.

Signed-off-by: mulhern <amulhern@redhat.com>