### PR TITLE
Use xenial distribution for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os: linux
+dist: xenial
 language: python
-python: "3.4" # dbus-python can not be built on higher versions of Python
+python: "3.5" # dbus-python can not be built on higher versions of Python
 
 addons:
   apt:


### PR DESCRIPTION
This allows moving the required version of Python from 3.4, which has
reached EOL, and which pip now deprecates, to 3.5.

Signed-off-by: mulhern <amulhern@redhat.com>