### PR TITLE
Remove license classifier deprecated by PEP 639

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ platforms =
 classifiers=
     Development Status :: 4 - Beta
     Intended Audience :: Developers
-    License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/774