### PR TITLE
Increase GitHub Action checkout version to v5 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: >
           dnf install -y
@@ -64,7 +64,7 @@ jobs:
           10
       - name: Display Python version
         run: python3 --version
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install dependencies
         run: >
           dnf install -y

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,8 @@ jobs:
     container: fedora:41  # CURRENT DEVELOPMENT ENVIRONMENT
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: >
           dnf install -y
@@ -65,6 +67,8 @@ jobs:
       - name: Display Python version
         run: python3 --version
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: >
           dnf install -y


### PR DESCRIPTION
Related https://github.com/stratis-storage/project/issues/807

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to use the latest checkout action and disabled credential persistence, improving pipeline security and reliability.
  * No user-facing changes; application behavior and features remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->